### PR TITLE
Add Hola Mundo wizard menu

### DIFF
--- a/whatsapp_connector/__manifest__.py
+++ b/whatsapp_connector/__manifest__.py
@@ -33,7 +33,8 @@
     'depends': [
         'bus',
         'sales_team',
-        'product'
+        'product',
+        'wk_wizard_messages'
     ],
     'data': [
         'data/data.xml',
@@ -68,6 +69,7 @@
         'reports/report_conversation_views.xml',
         'reports/report_agent_answer_time.xml',
         'views/res_config_settings_views.xml',
+        'views/my_custom_hello_views.xml',
         'views/menu.xml',
         'reports/reports.xml',
     ],

--- a/whatsapp_connector/views/menu.xml
+++ b/whatsapp_connector/views/menu.xml
@@ -13,6 +13,11 @@
                 id="whatsapp_connector_connector_menu"
                 parent="whatsapp_connector_settings_menu"
                 sequence="100"/>
+            <menuitem action="action_say_hello_world"
+                id="whatsapp_connector_hello_world_menu"
+                parent="whatsapp_connector_settings_menu"
+                name="Hola Mundo"
+                sequence="105"/>
             <menuitem action="view_whatsapp_connector_conversation_action"
                 id="whatsapp_connector_conversation_menu"
                 parent="whatsapp_connector_settings_menu"

--- a/whatsapp_connector/views/my_custom_hello_views.xml
+++ b/whatsapp_connector/views/my_custom_hello_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <record id="action_say_hello_world" model="ir.actions.act_window">
+            <field name="name">Hola Mundo</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wizard.message</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="context">{'default_text': 'Hola Mundo', 'default_message_type': 'text'}</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
## Summary
- enable wizard messages usage
- add Hello World action and menu entry

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68791f919624832482ab2493f19e2c44