### PR TITLE
Fix Google Search tab

### DIFF
--- a/whatsapp_connector/static/src/components/tabsContainer/tabsContainer.xml
+++ b/whatsapp_connector/static/src/components/tabsContainer/tabsContainer.xml
@@ -60,8 +60,11 @@
             <t t-set-slot="tab_google_search" isVisible="true"
                 name="'tab_google_search'" icon="'fa fa-search'"
                 id="'tab_google_search'" title="titles.tab_google_search">
-                <div class="o_GoogleSearchTab" style="height:100%;">
-                    <iframe src="https://www.google.com/" style="border:none;width:100%;height:100%;"></iframe>
+                <div class="o_GoogleSearchTab" style="padding:8px;">
+                    <form action="https://www.google.com/search" method="get" target="_blank" class="o_GoogleSearchForm">
+                        <input type="text" name="q" placeholder="Search Google..." required="required" style="width:80%;"/>
+                        <button type="submit" class="btn btn-primary">Search</button>
+                    </form>
                 </div>
             </t>
         </NotebookChat>


### PR DESCRIPTION
## Summary
- update the Google Search tab to avoid iframe issues

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7c7f82d0832494d14d6b7b66a9e7