### PR TITLE
Add in-tab Google search feature

### DIFF
--- a/whatsapp_connector/__manifest__.py
+++ b/whatsapp_connector/__manifest__.py
@@ -80,6 +80,7 @@
             'whatsapp_connector/static/src/components/*/*.xml',
 
             'whatsapp_connector/static/src/jslib/chatroom.js',
+            'whatsapp_connector/static/src/google_search.js',
         ],
         'web.assets_backend_prod_only': [
             'whatsapp_connector/static/src/services/chatroomNotification.js',

--- a/whatsapp_connector/static/src/components/tabsContainer/googleSearchTab.scss
+++ b/whatsapp_connector/static/src/components/tabsContainer/googleSearchTab.scss
@@ -1,0 +1,23 @@
+.o_GoogleSearchTab {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 8px;
+
+    .o_GoogleSearchForm {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 8px;
+
+        .form-select,
+        .form-control {
+            flex: 1 1 auto;
+        }
+    }
+
+    .o_GoogleSearchResult {
+        flex-grow: 1;
+        border: 0;
+        width: 100%;
+    }
+}

--- a/whatsapp_connector/static/src/components/tabsContainer/tabsContainer.xml
+++ b/whatsapp_connector/static/src/components/tabsContainer/tabsContainer.xml
@@ -60,11 +60,16 @@
             <t t-set-slot="tab_google_search" isVisible="true"
                 name="'tab_google_search'" icon="'fa fa-search'"
                 id="'tab_google_search'" title="titles.tab_google_search">
-                <div class="o_GoogleSearchTab" style="padding:8px;">
-                    <form action="https://www.google.com/search" method="get" target="_blank" class="o_GoogleSearchForm">
-                        <input type="text" name="q" placeholder="Search Google..." required="required" style="width:80%;"/>
+                <div class="o_GoogleSearchTab">
+                    <form class="o_GoogleSearchForm">
+                        <select name="tb" class="form-select" style="max-width:8rem;">
+                            <option value="">web</option>
+                            <option value="isch">imagenes</option>
+                        </select>
+                        <input type="text" name="q" placeholder="Search Google..." required="required" class="form-control"/>
                         <button type="submit" class="btn btn-primary">Search</button>
                     </form>
+                    <iframe class="o_GoogleSearchResult"/>
                 </div>
             </t>
         </NotebookChat>

--- a/whatsapp_connector/static/src/google_search.js
+++ b/whatsapp_connector/static/src/google_search.js
@@ -1,0 +1,15 @@
+odoo.define('whatsapp_connector.google_search', function (require) {
+    'use strict';
+    var $ = require('jquery');
+    $(document).on('submit', '.o_GoogleSearchForm', function (ev) {
+        ev.preventDefault();
+        var $form = $(this);
+        var query = $form.find('input[name="q"]').val();
+        var type = $form.find('select[name="tb"]').val();
+        var url = 'https://www.google.com/search?q=' + encodeURIComponent(query);
+        if (type) {
+            url += '&tb=' + encodeURIComponent(type);
+        }
+        $form.closest('.o_GoogleSearchTab').find('.o_GoogleSearchResult').attr('src', url);
+    });
+});


### PR DESCRIPTION
## Summary
- allow inline Google search inside the "Google Search" tab
- provide dropdown to search web or images
- style the Google Search tab
- load new JS for search logic

## Testing
- `python -m py_compile \
  `git ls-files '*.py'`

------
https://chatgpt.com/codex/tasks/task_e_688b82d986e08324977203ab7526c6de