### PR TITLE
Add Google search options

### DIFF
--- a/whatsapp_connector/__manifest__.py
+++ b/whatsapp_connector/__manifest__.py
@@ -80,6 +80,7 @@
             'whatsapp_connector/static/src/components/*/*.xml',
 
             'whatsapp_connector/static/src/jslib/chatroom.js',
+            'whatsapp_connector/static/src/js/google_search.js',
         ],
         'web.assets_backend_prod_only': [
             'whatsapp_connector/static/src/services/chatroomNotification.js',

--- a/whatsapp_connector/static/src/components/tabsContainer/tabsContainer.xml
+++ b/whatsapp_connector/static/src/components/tabsContainer/tabsContainer.xml
@@ -62,7 +62,11 @@
                 id="'tab_google_search'" title="titles.tab_google_search">
                 <div class="o_GoogleSearchTab" style="padding:8px;">
                     <form action="https://www.google.com/search" method="get" target="_blank" class="o_GoogleSearchForm">
-                        <input type="text" name="q" placeholder="Search Google..." required="required" style="width:80%;"/>
+                        <input type="text" name="q" placeholder="Search Google..." required="required" style="width:60%;"/>
+                        <select name="search_type" class="mx-1">
+                            <option value="web">Web</option>
+                            <option value="images">Images</option>
+                        </select>
                         <button type="submit" class="btn btn-primary">Search</button>
                     </form>
                 </div>

--- a/whatsapp_connector/static/src/js/google_search.js
+++ b/whatsapp_connector/static/src/js/google_search.js
@@ -1,0 +1,35 @@
+odoo.define('whatsapp_connector.google_search', function (require) {
+    'use strict';
+
+    $(document).ready(function () {
+        var $form = $('.o_GoogleSearchForm');
+        if (!$form.length) {
+            return;
+        }
+        var $iframe = $('<iframe>', {
+            class: 'o_GoogleResultsIframe',
+            style: 'display:none;width:100%;height:600px;border:none;'
+        });
+        $form.after($iframe);
+
+        $form.on('submit', function (ev) {
+            ev.preventDefault();
+            var query = $(this).find('input[name="q"]').val();
+            var type = $(this).find('select[name="search_type"]').val() || 'web';
+            var url = 'https://www.google.com/search?q=' + encodeURIComponent(query);
+            if (type === 'images') {
+                url = 'https://www.google.com/search?tbm=isch&q=' + encodeURIComponent(query);
+            }
+            if (window.open) {
+                window.open(url, '_blank', 'noopener');
+            }
+            if ($iframe.length) {
+                try {
+                    $iframe.attr('src', url).show();
+                } catch (e) {
+                    console.warn('Could not load results in iframe:', e);
+                }
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- extend Google search tab with selector for web or images
- open links via JS to avoid `window.opener`
- include optional results iframe

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b929c858c8324a8cc2b252ac6714a