### PR TITLE
Add magic wand button for voice notes

### DIFF
--- a/whatsapp_connector/static/src/components/message/message.scss
+++ b/whatsapp_connector/static/src/components/message/message.scss
@@ -18,6 +18,10 @@
         color: $o-gray-500;
     }
 
+    a.o_acrux_transcribe {
+        color: $o-gray-500;
+    }
+
     .o_chat_space {
         display: inline-block;
         vertical-align: middle;

--- a/whatsapp_connector/static/src/components/message/message.xml
+++ b/whatsapp_connector/static/src/components/message/message.xml
@@ -22,9 +22,9 @@
                         <t t-call="chatroom.MessageContent" />
                         <div>
                             <t t-if="canTranscribe and !props.noAction">
-                                <a href="#" class="mt-2 fw-bold o_acrux_transcribe" title="Transcribe to text"
+                                <a href="#" class="mt-2 o_acrux_transcribe" title="Transcribe to text"
                                     t-on-click="onTranscribe">
-                                    Transcribe
+                                    <i class="fa fa-magic" />
                                 </a>
                             </t>
                             <span t-if="message.transcription" t-out="message.transcription"


### PR DESCRIPTION
## Summary
- show a magic wand button for transcribing audio messages
- style the new button subtly in gray

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688be131b2fc83248ea761b8044edd98