### PR TITLE
Add transcription AI config module

### DIFF
--- a/chatroom_inhiretance/__manifest__.py
+++ b/chatroom_inhiretance/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'ChatRoom Inhiretance',
+    'version': '16.0.1.0.0',
+    'summary': 'Customization for ChatRoom AI settings',
+    'author': 'Chatroom',
+    'license': 'OPL-1',
+    'category': 'Discuss',
+    'depends': ['whatsapp_connector'],
+    'data': [
+        'data/ai_config_data.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/chatroom_inhiretance/data/ai_config_data.xml
+++ b/chatroom_inhiretance/data/ai_config_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="chatroom_ai_config_transcription" model="acrux.chat.ai.config">
+            <field name="name">Transcription</field>
+            <field name="operation_id" ref="whatsapp_connector.data_config_operation_transcription"/>
+            <field name="ai_model_id" ref="whatsapp_connector.data_config_operation_transcription_1"/>
+            <field name="auth_token">X</field>
+            <field name="temperature">0.2</field>
+            <field name="sequence">99</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
## Summary
- add a new `chatroom_inhiretance` module
- include default AI configuration for audio transcriptions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688be3ae48c083248aa99a78b944fdcb