### PR TITLE
Add calculator tab to chat via inheritance

### DIFF
--- a/chatroom_inhiretance/__manifest__.py
+++ b/chatroom_inhiretance/__manifest__.py
@@ -8,6 +8,10 @@
     'depends': ['whatsapp_connector'],
     'data': [
         'data/ai_config_data.xml',
+        'views/include_template.xml',
+    ],
+    'qweb': [
+        'static/src/xml/tabs_extension.xml',
     ],
     'installable': True,
     'application': False,

--- a/chatroom_inhiretance/static/src/js/calculator.js
+++ b/chatroom_inhiretance/static/src/js/calculator.js
@@ -1,0 +1,26 @@
+odoo.define('chatroom_inhiretance.calculator', function (require) {
+    'use strict';
+
+    $(document).ready(function () {
+        var $calc = $('.o_Calculator');
+        if (!$calc.length) {
+            return;
+        }
+        var $display = $calc.find('.o_CalcDisplay input');
+        $calc.on('click', '.o_CalcButton', function () {
+            var val = $(this).data('value');
+            if (val === 'C') {
+                $display.val('');
+            } else if (val === '=') {
+                try {
+                    var result = eval($display.val() || '0');
+                    $display.val(result);
+                } catch (e) {
+                    $display.val('Error');
+                }
+            } else {
+                $display.val($display.val() + val);
+            }
+        });
+    });
+});

--- a/chatroom_inhiretance/static/src/js/tabs_patch.js
+++ b/chatroom_inhiretance/static/src/js/tabs_patch.js
@@ -1,0 +1,12 @@
+odoo.define('chatroom_inhiretance.tabs_patch', function (require) {
+    'use strict';
+    const { patch } = require('@web/core/utils/patch');
+    const { TabsContainer } = require('@af0df1a5affde864bfaca0edba19137ac4e7199f2cb7ae310c45d7b47aaac68b');
+
+    patch(TabsContainer.prototype, 'chatroom_inhiretance.tabs_patch', {
+        get titles() {
+            const base = this._super();
+            return Object.assign({}, base, { tab_calculator: this.env._t('Calculator') });
+        },
+    });
+});

--- a/chatroom_inhiretance/static/src/scss/calculator.scss
+++ b/chatroom_inhiretance/static/src/scss/calculator.scss
@@ -1,0 +1,15 @@
+// Calculator tab styles
+.o_CalculatorTab {
+    max-width: 260px;
+    padding: 8px;
+}
+
+.o_CalcDisplay input {
+    text-align: right;
+}
+
+.o_CalcButtons {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 4px;
+}

--- a/chatroom_inhiretance/static/src/xml/tabs_extension.xml
+++ b/chatroom_inhiretance/static/src/xml/tabs_extension.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-extend="chatroom.TabsContainer">
+        <t t-jquery="t[t-set-slot='tab_google_search']" t-operation="after">
+            <t t-set-slot="tab_calculator" isVisible="true"
+                name="'tab_calculator'" icon="'fa fa-calculator'"
+                id="'tab_calculator'" title="'Calculator'">
+                <div class="o_CalculatorTab o_Calculator">
+                    <div class="o_CalcDisplay mb-2">
+                        <input type="text" readonly="readonly" placeholder="0" class="form-control"/>
+                    </div>
+                    <div class="o_CalcButtons">
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="7">7</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="8">8</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="9">9</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="/">/</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="4">4</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="5">5</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="6">6</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="*">*</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="1">1</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="2">2</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="3">3</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="-">-</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="0">0</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value=".">.</button>
+                        <button type="button" class="btn btn-success o_CalcButton" data-value="=">=</button>
+                        <button type="button" class="btn btn-light o_CalcButton" data-value="+">+</button>
+                        <button type="button" class="btn btn-danger o_CalcButton" data-value="C">C</button>
+                    </div>
+                </div>
+            </t>
+        </t>
+    </t>
+</templates>

--- a/chatroom_inhiretance/views/include_template.xml
+++ b/chatroom_inhiretance/views/include_template.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="assets_backend" name="chatroom inheritance assets" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/chatroom_inhiretance/static/src/js/calculator.js"/>
+            <script type="text/javascript" src="/chatroom_inhiretance/static/src/js/tabs_patch.js"/>
+            <link rel="stylesheet" href="/chatroom_inhiretance/static/src/scss/calculator.scss" type="text/scss"/>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Summary
- add assets and view overrides in `chatroom_inhiretance`
- implement calculator functionality and tab extension
- include custom SCSS for calculator styling

## Testing
- `python -m py_compile chatroom_inhiretance/__manifest__.py`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688cc8ca7db8832486da26eac4c9db72