### PR TITLE
Add product search filters

### DIFF
--- a/whatsapp_connector/static/src/components/chatSearch/chatSearch.xml
+++ b/whatsapp_connector/static/src/components/chatSearch/chatSearch.xml
@@ -3,6 +3,20 @@
     
     <t t-name="chatroom.ChatSearch" owl="1">
         <div class="o_ChatSearch form-inline">
+            <div t-if="props.showSearchType" class="form-group mr-1">
+                <select class="form-control" t-ref="selectSearchType">
+                    <option value="name"><t t-esc="env._t('Name')" /></option>
+                    <option value="description"><t t-esc="env._t('Description')" /></option>
+                </select>
+            </div>
+            <div t-if="props.showQtyFilter" class="form-group mr-1">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" t-ref="checkQty" id="chat_search_qty" />
+                    <label class="form-check-label" for="chat_search_qty">
+                        <t t-esc="env._t('Available')" />
+                    </label>
+                </div>
+            </div>
             <div class="form-group">
                 <input type="text" class="o_search_input"
                     t-att-placeholder="props.placeHolder"

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.xml
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.xml
@@ -4,7 +4,7 @@
     <t t-name="chatroom.ProductContainer" owl="1">
         <div class="acrux_ProductContainer" t-attf-class="{{ props.className }}">
             <ChatroomHeader className="'o_product_header'">
-                <ChatSearch placeHolder="placeHolder" eventName="'productSearch'" />
+                <ChatSearch placeHolder="placeHolder" eventName="'productSearch'" showQtyFilter="True" showSearchType="True" />
             </ChatroomHeader>
             <div class="o_acrux_chat_product_items">
                 <t t-foreach="state.products" t-as="product" t-key="product.id">

--- a/whatsapp_connector/static/src/jslib/chatroom.js
+++ b/whatsapp_connector/static/src/jslib/chatroom.js
@@ -595,11 +595,19 @@ odoo.define('@b776165a95553fcc22eda64dc09cd1e02d2db4727ab51cf648290a373a0251c6',
     setup() {
       super.setup()
       this.env; this.props; this.inputSearch = useRef('inputSearch')
+      if (this.props.showSearchType) this.selectSearchType = useRef('selectSearchType')
+      if (this.props.showQtyFilter) this.checkQty = useRef('checkQty')
     }
-    onKeypress(event) { if (event.which === 13) { this.env.chatBus.trigger(this.props.eventName, { search: this.inputSearch.el.value }) } }
-    onSearch() { this.env.chatBus.trigger(this.props.eventName, { search: this.inputSearch.el.value }) }
+    onKeypress(event) { if (event.which === 13) { this.triggerSearch() } }
+    onSearch() { this.triggerSearch() }
+    triggerSearch() {
+      const data = { search: this.inputSearch.el.value }
+      if (this.props.showSearchType) data.searchField = this.selectSearchType.el.value
+      if (this.props.showQtyFilter) data.qtyAvailable = this.checkQty.el.checked
+      this.env.chatBus.trigger(this.props.eventName, data)
+    }
   }
-  Object.assign(ChatSearch, { template: 'chatroom.ChatSearch', props: { placeHolder: { type: String, optional: true }, eventName: String, }, defaultProps: { placeHolder: '', } })
+  Object.assign(ChatSearch, { template: 'chatroom.ChatSearch', props: { placeHolder: { type: String, optional: true }, eventName: String, showQtyFilter: { type: Boolean, optional: true }, showSearchType: { type: Boolean, optional: true } }, defaultProps: { placeHolder: '', showQtyFilter: false, showSearchType: false } })
   return __exports;
 });;
 odoo.define('@42ffbf6224f23aacdf6b9a6289d4e396904ef6225cba7443d521319d2137e2b6', async function (require) {
@@ -1468,10 +1476,10 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
       this.env.chatBus.off('productSearch', this)
       this.env.chatBus.off('productOption', this)
     }
-    async searchProduct({ search }) {
+    async searchProduct({ search, qtyAvailable, searchField }) {
       let val = search || ''
       const { orm } = this.env.services
-      const result = await orm.call(this.env.chatModel, 'search_product', [val.trim()], { context: this.env.context })
+      const result = await orm.call(this.env.chatModel, 'search_product', [val.trim(), searchField || 'name', qtyAvailable || false], { context: this.env.context })
       this.state.products = result.map(product => new ProductModel(this, product))
     }
     async productOption({ product, event }) { if (this.props.selectedConversation) { if (this.props.selectedConversation.isMine()) { await this.doProductOption({ product, event }) } else { this.env.services.dialog.add(WarningDialog, { message: this.env._t('Yoy are not writing in this conversation.') }) } } else { this.env.services.dialog.add(WarningDialog, { message: this.env._t('You must select a conversation.') }) } }


### PR DESCRIPTION
## Summary
- enable optional filters in the chat search component
- show available and search type options on product tab
- support qty_available and description filters server‑side

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688ceccbafcc832497617aa840cff5d6