### PR TITLE
Add product search filters

### DIFF
--- a/whatsapp_connector/static/src/components/productContainer/productContainer.scss
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.scss
@@ -6,6 +6,14 @@
     .o_product_header {
         background: transparent;
         border: 0;
+        .o_product_filters {
+            display: flex;
+            align-items: center;
+            margin-left: 8px;
+            label {
+                margin-bottom: 0;
+            }
+        }
     }
 
     .o_acrux_chat_product_items {

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.xml
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.xml
@@ -5,6 +5,20 @@
         <div class="acrux_ProductContainer" t-attf-class="{{ props.className }}">
             <ChatroomHeader className="'o_product_header'">
                 <ChatSearch placeHolder="placeHolder" eventName="'productSearch'" />
+                <div class="o_product_filters">
+                    <label class="me-2">
+                        <input type="checkbox" t-on-change="toggleAvailable"/>
+                        <span> Stock &gt; 0</span>
+                    </label>
+                    <label class="me-2">
+                        <input type="checkbox" t-on-change="toggleSearchName"/>
+                        <span> Nombre</span>
+                    </label>
+                    <label>
+                        <input type="checkbox" t-on-change="toggleSearchDescription"/>
+                        <span> Descripción</span>
+                    </label>
+                </div>
             </ChatroomHeader>
             <div class="o_acrux_chat_product_items">
                 <t t-foreach="state.products" t-as="product" t-key="product.id">

--- a/whatsapp_connector/static/src/jslib/chatroom.js
+++ b/whatsapp_connector/static/src/jslib/chatroom.js
@@ -1456,7 +1456,13 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
   const ProductContainer = __exports.ProductContainer = class ProductContainer extends Component {
     setup() {
       super.setup()
-      this.env; this.state = useState({ products: [] })
+      this.env; this.state = useState({
+        products: [],
+        available: false,
+        searchName: false,
+        searchDescription: false,
+      })
+      this.lastSearch = ''
       this.props
       this.placeHolder = this.env._t('Search')
       this.env.chatBus.on('productSearch', this, this.searchProduct)
@@ -1470,9 +1476,32 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
     }
     async searchProduct({ search }) {
       let val = search || ''
+      this.lastSearch = val
       const { orm } = this.env.services
-      const result = await orm.call(this.env.chatModel, 'search_product', [val.trim()], { context: this.env.context })
+      const filters = {
+        available: this.state.available,
+        search_name: this.state.searchName,
+        search_description: this.state.searchDescription,
+      }
+      const result = await orm.call(
+        this.env.chatModel,
+        'search_product',
+        [val.trim(), filters],
+        { context: this.env.context },
+      )
       this.state.products = result.map(product => new ProductModel(this, product))
+    }
+    toggleAvailable() {
+      this.state.available = !this.state.available
+      this.searchProduct({ search: this.lastSearch })
+    }
+    toggleSearchName() {
+      this.state.searchName = !this.state.searchName
+      this.searchProduct({ search: this.lastSearch })
+    }
+    toggleSearchDescription() {
+      this.state.searchDescription = !this.state.searchDescription
+      this.searchProduct({ search: this.lastSearch })
     }
     async productOption({ product, event }) { if (this.props.selectedConversation) { if (this.props.selectedConversation.isMine()) { await this.doProductOption({ product, event }) } else { this.env.services.dialog.add(WarningDialog, { message: this.env._t('Yoy are not writing in this conversation.') }) } } else { this.env.services.dialog.add(WarningDialog, { message: this.env._t('You must select a conversation.') }) } }
     async doProductOption({ product }) {


### PR DESCRIPTION
## Summary
- allow reading `qty_available` for products
- add search filters by name, description and stock
- support toggling filters in Product tab UI
- style filter section in product container

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688cf61c0a4483248761fa2bef9b7c0c