### PR TITLE
Enhance product search filters

### DIFF
--- a/chatroom_cantidad_productos/models/conversation.py
+++ b/chatroom_cantidad_productos/models/conversation.py
@@ -1,49 +1,31 @@
-from odoo import fields, models,api
+from odoo import fields, models, api
 from odoo.tools.translate import _
 import logging
+
 _logger = logging.getLogger(__name__)
+
 
 class AcruxChatConversation(models.Model):
     _inherit = 'acrux.chat.conversation'
 
     @api.model
     def get_product_fields_to_read(self):
-        fields_search = ['id', 'display_name', 'lst_price', 'uom_id',
-                         'write_date', 'product_tmpl_id', 'name', 'type', 'default_code']
+        fields_search = [
+            'id', 'display_name', 'lst_price', 'uom_id',
+            'write_date', 'product_tmpl_id', 'name', 'type', 'default_code'
+        ]
         if 'quantity_in_location' in self.env['product.product']._fields:
             fields_search.append('quantity_total')
         return fields_search
 
     @api.model
     def search_product(self, string, filters=None):
-    #CASI ME VUELVO GAY BUSCANDO ESTA FUNCIÓN"""
-    #JC ESTUVO AQUÍ
-    #ANTIGUA FUNCIÓN
-    
-    # def search_product(self, string):
-
-    #     if not string:
-    #         return []
-    #     ProductProduct = self.env['product.product']
-    #     domain = [('sale_ok', '=', True)]
-    #     if string:
-    #         if string.startswith('/cat '):
-    #             domain += [('categ_id.complete_name', 'ilike', string[5:].strip())]
-    #         else:
-    #             domain += ['|', ('name', 'ilike', string), ('default_code', 'ilike', string)]
-    #     fields_search = self.get_product_fields_to_read()
-    #     out = ProductProduct.search_read(domain, fields_search, order='name, list_price')
-
-        
-    #     # Filtrar los diccionarios que cumplen con la condición quantity_in_location > 0
-    #     out_filtered = [product_dict for product_dict in out if product_dict.get('quantity_total', 0) > 0]
-        
-    #     return out_filtered
-
-
         products = super().search_product(string, filters=filters)
 
         if 'quantity_total' in self.env['product.product']._fields:
-            products = [prod for prod in products if prod.get('quantity_total', 0) > 0]
-
+            stock_filter = (filters or {}).get('stock_filter', 'positive')
+            if stock_filter == 'positive':
+                products = [p for p in products if p.get('quantity_total', 0) > 0]
+            elif stock_filter == 'negative':
+                products = [p for p in products if p.get('quantity_total', 0) < 0]
         return products

--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -712,8 +712,14 @@ class AcruxChatConversation(models.Model):
         ProductProduct = self.env['product.product']
         domain = [('sale_ok', '=', True)]
         filters = filters or {}
-        if filters.get('available') and 'qty_available' in ProductProduct._fields:
-            domain.append(('qty_available', '>', 0))
+        stock_filter = filters.get('stock_filter')
+        if not stock_filter and filters.get('available'):
+            stock_filter = 'positive'
+        if stock_filter and 'qty_available' in ProductProduct._fields:
+            if stock_filter == 'positive':
+                domain.append(('qty_available', '>', 0))
+            elif stock_filter == 'negative':
+                domain.append(('qty_available', '<', 0))
         if string:
             if string.startswith('/cat '):
                 domain += [('categ_id.complete_name', 'ilike', string[5:].strip())]

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.xml
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.xml
@@ -6,16 +6,17 @@
             <ChatroomHeader className="'o_product_header'">
                 <ChatSearch placeHolder="placeHolder" eventName="'productSearch'" />
                 <div class="o_product_filters">
+                    <select class="form-select form-select-sm me-2" t-on-change="changeStockFilter">
+                        <option value="positive">Stock &gt; 0</option>
+                        <option value="negative">Stock &lt; 0</option>
+                        <option value="all">Todos</option>
+                    </select>
                     <label class="me-2">
-                        <input type="checkbox" t-on-change="toggleAvailable"/>
-                        <span> Stock &gt; 0</span>
-                    </label>
-                    <label class="me-2">
-                        <input type="checkbox" t-on-change="toggleSearchName"/>
+                        <input type="checkbox" t-on-change="toggleSearchName" t-att-checked="state.searchName"/>
                         <span> Nombre</span>
                     </label>
                     <label>
-                        <input type="checkbox" t-on-change="toggleSearchDescription"/>
+                        <input type="checkbox" t-on-change="toggleSearchDescription" t-att-checked="state.searchDescription"/>
                         <span> Descripción</span>
                     </label>
                 </div>

--- a/whatsapp_connector/static/src/jslib/chatroom.js
+++ b/whatsapp_connector/static/src/jslib/chatroom.js
@@ -1458,8 +1458,8 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
       super.setup()
       this.env; this.state = useState({
         products: [],
-        available: false,
-        searchName: false,
+        stockFilter: 'positive',
+        searchName: true,
         searchDescription: false,
       })
       this.lastSearch = ''
@@ -1479,7 +1479,7 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
       this.lastSearch = val
       const { orm } = this.env.services
       const filters = {
-        available: this.state.available,
+        stock_filter: this.state.stockFilter,
         search_name: this.state.searchName,
         search_description: this.state.searchDescription,
       }
@@ -1491,8 +1491,8 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
       )
       this.state.products = result.map(product => new ProductModel(this, product))
     }
-    toggleAvailable() {
-      this.state.available = !this.state.available
+    changeStockFilter(event) {
+      this.state.stockFilter = event.target.value
       this.searchProduct({ search: this.lastSearch })
     }
     toggleSearchName() {


### PR DESCRIPTION
## Summary
- add dropdown for stock filters in product container
- support stock filter logic in server search
- handle stock filter for quantity_total addon
- default filter is stock > 0 and search by name

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d206d25748324b954bbb23056d635