### PR TITLE
Add product stock info via extension

### DIFF
--- a/chatroom_tarjeta_productos/__init__.py
+++ b/chatroom_tarjeta_productos/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/chatroom_tarjeta_productos/__manifest__.py
+++ b/chatroom_tarjeta_productos/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'Tarjeta de Productos Chatroom',
+    'summary': 'Muestra cantidades por bodega en tarjetas de productos',
+    'version': '1.0',
+    'author': 'Juan José Gamboa Ortiz',
+    'depends': ['whatsapp_connector', 'product_cant_tecnolosys', 'chatroom_cantidad_productos'],
+    'data': [],
+    'assets': {
+        'web.assets_backend': [
+            'chatroom_tarjeta_productos/static/src/components/*/*.xml',
+            'chatroom_tarjeta_productos/static/src/components/*/*.scss',
+            'chatroom_tarjeta_productos/static/src/js/product_patch.js',
+        ],
+    },
+    'installable': True,
+    'license': 'GPL-3',
+}

--- a/chatroom_tarjeta_productos/models/__init__.py
+++ b/chatroom_tarjeta_productos/models/__init__.py
@@ -1,0 +1,2 @@
+from . import conversation
+from . import product

--- a/chatroom_tarjeta_productos/models/conversation.py
+++ b/chatroom_tarjeta_productos/models/conversation.py
@@ -1,0 +1,32 @@
+from odoo import models, api
+
+
+class AcruxChatConversation(models.Model):
+    _inherit = 'acrux.chat.conversation'
+
+    @api.model
+    def get_product_fields_to_read(self):
+        fields_search = super().get_product_fields_to_read()
+        Product = self.env['product.product']
+        if 'quantity_in_location' in Product._fields:
+            extra = [
+                'quantity_in_location',
+                'quantity_in_tulipanes',
+                'quantity_in_neutron',
+            ]
+            for field in extra:
+                if field not in fields_search:
+                    fields_search.append(field)
+        return fields_search
+
+    @api.model
+    def search_product(self, string, filters=None):
+        products = super().search_product(string, filters=filters)
+        Product = self.env['product.product']
+        if 'quantity_in_location' in Product._fields:
+            stock_filter = (filters or {}).get('stock_filter', 'positive')
+            if stock_filter == 'positive':
+                products = [p for p in products if p.get('quantity_total', 0) > 0]
+            elif stock_filter == 'negative':
+                products = [p for p in products if p.get('quantity_total', 0) < 0]
+        return products

--- a/chatroom_tarjeta_productos/models/product.py
+++ b/chatroom_tarjeta_productos/models/product.py
@@ -1,0 +1,22 @@
+from odoo import models, fields
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    quantity_in_location = fields.Float(
+        related='product_tmpl_id.quantity_in_location',
+        readonly=True,
+    )
+    quantity_in_tulipanes = fields.Float(
+        related='product_tmpl_id.quantity_in_tulipanes',
+        readonly=True,
+    )
+    quantity_in_neutron = fields.Float(
+        related='product_tmpl_id.quantity_in_neutron',
+        readonly=True,
+    )
+    quantity_total = fields.Float(
+        related='product_tmpl_id.quantity_total',
+        readonly=True,
+    )

--- a/chatroom_tarjeta_productos/static/src/components/chatSearch/chatSearch.scss
+++ b/chatroom_tarjeta_productos/static/src/components/chatSearch/chatSearch.scss
@@ -1,0 +1,3 @@
+.o_ChatSearch .form-group .o_search_input {
+    width: 15em;
+}

--- a/chatroom_tarjeta_productos/static/src/components/product/product.xml
+++ b/chatroom_tarjeta_productos/static/src/components/product/product.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-extend="chatroom.Product">
+        <t t-jquery="ul li:last-child" t-operation="after">
+            <li class="small">SAN = <t t-esc="props.product.qtySan"/> UND</li>
+            <li class="small">TUL = <t t-esc="props.product.qtyTul"/> UND</li>
+            <li class="small">NEU = <t t-esc="props.product.qtyNeu"/> UND</li>
+        </t>
+    </t>
+</templates>

--- a/chatroom_tarjeta_productos/static/src/components/productContainer/productContainer.scss
+++ b/chatroom_tarjeta_productos/static/src/components/productContainer/productContainer.scss
@@ -1,0 +1,8 @@
+.acrux_ProductContainer .o_product_header {
+    flex-direction: column;
+    align-items: flex-start;
+}
+.acrux_ProductContainer .o_product_header .o_product_filters {
+    margin-left: 0;
+    margin-top: 4px;
+}

--- a/chatroom_tarjeta_productos/static/src/components/productContainer/productContainer.xml
+++ b/chatroom_tarjeta_productos/static/src/components/productContainer/productContainer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-extend="chatroom.ProductContainer">
+        <t t-jquery="select[t-on-change='changeStockFilter'] option[value='positive']" t-operation="replace">
+            <option value="positive">Unidades mayor a 0</option>
+        </t>
+        <t t-jquery="select[t-on-change='changeStockFilter'] option[value='negative']" t-operation="replace">
+            <option value="negative">Unidades menor a 0</option>
+        </t>
+    </t>
+</templates>

--- a/chatroom_tarjeta_productos/static/src/js/product_patch.js
+++ b/chatroom_tarjeta_productos/static/src/js/product_patch.js
@@ -1,0 +1,30 @@
+odoo.define('chatroom_tarjeta_productos.product_patch', async function (require) {
+    'use strict';
+    let __exports = {};
+    const { patch } = require('@web/core/utils/patch');
+    const { ProductModel } = require('@a57f7a72eb29be2e68a9675edd680394d67e2ecd8df85dc2c38e83822c8551e8');
+
+    const productPatch = {
+        constructor() {
+            this._super(...arguments);
+            this.qtySan = 0.0;
+            this.qtyTul = 0.0;
+            this.qtyNeu = 0.0;
+        },
+        updateFromJson(base) {
+            this._super(base);
+            if ('quantity_in_location' in base) {
+                this.qtySan = base.quantity_in_location;
+            }
+            if ('quantity_in_tulipanes' in base) {
+                this.qtyTul = base.quantity_in_tulipanes;
+            }
+            if ('quantity_in_neutron' in base) {
+                this.qtyNeu = base.quantity_in_neutron;
+            }
+        },
+    };
+    patch(ProductModel.prototype, 'chatroom_tarjeta_productos', productPatch);
+    return __exports;
+});
+


### PR DESCRIPTION
## Summary
- revert direct changes to base modules
- introduce new `chatroom_tarjeta_productos` addon with stock fields and patches
- patch product model in JS to expose stock by location
- display SAN/TUL/NEU stock lines on product cards
- tweak filters and search layout via inherited templates and styles

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688d2814620083249b4df829fbbbc246