### PR TITLE
Allow get_for_chatroom to accept ids parameter

### DIFF
--- a/whatsapp_connector/models/DefaultAnswer.py
+++ b/whatsapp_connector/models/DefaultAnswer.py
@@ -114,7 +114,12 @@ class AcruxChatDefaultAnswer(models.Model):
                 'button_ids', 'chat_list_id']
 
     @api.model
-    def get_for_chatroom(self):
+    def get_for_chatroom(self, ids=None):
+        """Return default answers for chatroom.
+
+        The ``ids`` argument is ignored but kept for RPC compatibility,
+        as some clients send an empty list when calling this method.
+        """
         out = self.search_read([('show_in_chatroom', '=', True)], self.get_fields_to_read())
         ButtonModel = self.env['acrux.chat.default.message.button']
         button_fields = self.env['acrux.chat.button.base'].fields_get().keys()


### PR DESCRIPTION
## Summary
- extend `get_for_chatroom` with an optional `ids` argument so RPC calls that pass an ID list remain compatible

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d44af6f448324ab47707fc4bb6eba