### PR TITLE
Show stock quantities per location in product cards

### DIFF
--- a/chatroom_cantidad_productos/models/conversation.py
+++ b/chatroom_cantidad_productos/models/conversation.py
@@ -10,12 +10,13 @@ class AcruxChatConversation(models.Model):
 
     @api.model
     def get_product_fields_to_read(self):
-        fields_search = [
-            'id', 'display_name', 'lst_price', 'uom_id',
-            'write_date', 'product_tmpl_id', 'name', 'type', 'default_code'
-        ]
+        fields_search = super().get_product_fields_to_read()
         if 'quantity_in_location' in self.env['product.product']._fields:
-            fields_search.append('quantity_total')
+            fields_search.extend([
+                'quantity_in_location',
+                'quantity_in_tulipanes',
+                'quantity_in_neutron',
+            ])
         return fields_search
 
     @api.model

--- a/whatsapp_connector/static/src/components/product/product.xml
+++ b/whatsapp_connector/static/src/components/product/product.xml
@@ -28,6 +28,11 @@
                                 </t>
                             </t>
                         </li>
+                        <li class="small" t-if="props.product.type == 'product'">
+                            <span>SAN = <t t-esc="props.product.qtyLocation"/> UND</span>
+                            <span style="margin-left: 8px;">TUL = <t t-esc="props.product.qtyTulipanes"/> UND</span>
+                            <span style="margin-left: 8px;">NEU = <t t-esc="props.product.qtyNeutron"/> UND</span>
+                        </li>
                         <li class="small" style="color: #858585;">
                             <span t-if="props.product.defaultCode">
                                 <t t-esc="props.product.defaultCode"/>

--- a/whatsapp_connector/static/src/jslib/chatroom.js
+++ b/whatsapp_connector/static/src/jslib/chatroom.js
@@ -2360,6 +2360,9 @@ odoo.define('@a57f7a72eb29be2e68a9675edd680394d67e2ecd8df85dc2c38e83822c8551e8',
       this.defaultCode = ''
       this.qtyAvailable = 0.0
       this.qtyAvailabletecno = 0.0
+      this.qtyLocation = 0.0
+      this.qtyTulipanes = 0.0
+      this.qtyNeutron = 0.0
       this.showProductText = true
       this.uniqueHashImage = ''
       this.showOptions = true
@@ -2381,6 +2384,9 @@ odoo.define('@a57f7a72eb29be2e68a9675edd680394d67e2ecd8df85dc2c38e83822c8551e8',
       if ('default_code' in base) { this.defaultCode = base.default_code }
       if ('qty_available' in base) { this.qtyAvailable = base.qty_available }
       if ('quantity_total' in base) { this.qtyAvailabletecno = base.quantity_total }
+      if ('quantity_in_location' in base) { this.qtyLocation = base.quantity_in_location }
+      if ('quantity_in_tulipanes' in base) { this.qtyTulipanes = base.quantity_in_tulipanes }
+      if ('quantity_in_neutron' in base) { this.qtyNeutron = base.quantity_in_neutron }
       if ('show_product_text' in base) { this.showProductText = base.show_product_text }
       if ('show_options' in base) { this.showOptions = base.show_options }
     }


### PR DESCRIPTION
## Summary
- Display stock quantities in SAN, TUL and NEU locations on product cards
- Include new quantity fields in product search results

## Testing
- `python -m py_compile chatroom_cantidad_productos/models/conversation.py`
- `node --check whatsapp_connector/static/src/jslib/chatroom.js`
- `xmllint --noout whatsapp_connector/static/src/components/product/product.xml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e2641fd508324bdca1a2199763757