### PR TITLE
Add default code filter to product search

### DIFF
--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -726,15 +726,17 @@ class AcruxChatConversation(models.Model):
             else:
                 search_name = filters.get('search_name')
                 search_description = filters.get('search_description')
-                if search_name or search_description:
-                    if search_name and search_description:
-                        domain += ['|',
-                                   ('product_tmpl_id.name', 'ilike', string),
-                                   ('product_tmpl_id.description', 'ilike', string)]
-                    elif search_name:
-                        domain.append(('product_tmpl_id.name', 'ilike', string))
-                    else:
-                        domain.append(('product_tmpl_id.description', 'ilike', string))
+                search_default_code = filters.get('search_default_code')
+                if search_name or search_description or search_default_code:
+                    exprs = []
+                    if search_name:
+                        exprs.append([('product_tmpl_id.name', 'ilike', string)])
+                    if search_description:
+                        exprs.append([('product_tmpl_id.description', 'ilike', string)])
+                    if search_default_code:
+                        exprs.append([('default_code', 'ilike', string)])
+                    if exprs:
+                        domain += expression.OR(exprs)
                 else:
                     domain += ['|', ('name', 'ilike', string), ('default_code', 'ilike', string)]
         fields_search = self.get_product_fields_to_read()

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.xml
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.xml
@@ -15,6 +15,10 @@
                         <input type="checkbox" t-on-change="toggleSearchName" t-att-checked="state.searchName"/>
                         <span> Nombre</span>
                     </label>
+                    <label class="me-2">
+                        <input type="checkbox" t-on-change="toggleSearchDefaultCode" t-att-checked="state.searchDefaultCode"/>
+                        <span> Referencia</span>
+                    </label>
                     <label>
                         <input type="checkbox" t-on-change="toggleSearchDescription" t-att-checked="state.searchDescription"/>
                         <span> Descripción</span>

--- a/whatsapp_connector/static/src/jslib/chatroom.js
+++ b/whatsapp_connector/static/src/jslib/chatroom.js
@@ -1461,6 +1461,7 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
         stockFilter: 'positive',
         searchName: true,
         searchDescription: false,
+        searchDefaultCode: true,
       })
       this.lastSearch = ''
       this.props
@@ -1482,6 +1483,7 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
         stock_filter: this.state.stockFilter,
         search_name: this.state.searchName,
         search_description: this.state.searchDescription,
+        search_default_code: this.state.searchDefaultCode,
       }
       const result = await orm.call(
         this.env.chatModel,
@@ -1501,6 +1503,10 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
     }
     toggleSearchDescription() {
       this.state.searchDescription = !this.state.searchDescription
+      this.searchProduct({ search: this.lastSearch })
+    }
+    toggleSearchDefaultCode() {
+      this.state.searchDefaultCode = !this.state.searchDefaultCode
       this.searchProduct({ search: this.lastSearch })
     }
     async productOption({ product, event }) { if (this.props.selectedConversation) { if (this.props.selectedConversation.isMine()) { await this.doProductOption({ product, event }) } else { this.env.services.dialog.add(WarningDialog, { message: this.env._t('Yoy are not writing in this conversation.') }) } } else { this.env.services.dialog.add(WarningDialog, { message: this.env._t('You must select a conversation.') }) } }


### PR DESCRIPTION
## Summary
- add internal reference filter to product search view with default activation
- include server-side support for `default_code` search

## Testing
- `python -m py_compile whatsapp_connector/models/Conversation.py`
- `node --check whatsapp_connector/static/src/jslib/chatroom.js`
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890cb121afc832488a632104d03211d