### PR TITLE
Fix product search card alignment and labels

### DIFF
--- a/whatsapp_connector/static/src/components/product/product.xml
+++ b/whatsapp_connector/static/src/components/product/product.xml
@@ -28,11 +28,17 @@
                                 </t>
                             </t>
                         </li>
-                        <li class="small" t-if="props.product.type == 'product'">
-                            <span>SAN = <t t-esc="props.product.qtyLocation"/> UND</span>
-                            <span style="margin-left: 8px;">TUL = <t t-esc="props.product.qtyTulipanes"/> UND</span>
-                            <span style="margin-left: 8px;">NEU = <t t-esc="props.product.qtyNeutron"/> UND</span>
-                        </li>
+                        <t t-if="props.product.type == 'product'">
+                            <li class="small">
+                                <span><strong>SAN</strong> <strong><t t-esc="props.product.qtyLocation"/></strong> UND</span>
+                            </li>
+                            <li class="small">
+                                <span><strong>TUL</strong> <strong><t t-esc="props.product.qtyTulipanes"/></strong> UND</span>
+                            </li>
+                            <li class="small">
+                                <span><strong>NEU</strong> <strong><t t-esc="props.product.qtyNeutron"/></strong> UND</span>
+                            </li>
+                        </t>
                         <li class="small" style="color: #858585;">
                             <span t-if="props.product.defaultCode">
                                 <t t-esc="props.product.defaultCode"/>

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.scss
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.scss
@@ -48,5 +48,7 @@
         grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
         gap: 16px;
         padding: 0;
+        align-content: start;
+        align-items: start;
     }
 }


### PR DESCRIPTION
## Summary
- Prevent product cards from stretching when single reference search by aligning grid items to the start
- Show SAN, TUL and NEU quantities in bold on separate rows without equals sign

## Testing
- `pre-commit run --files whatsapp_connector/static/src/components/product/product.xml whatsapp_connector/static/src/components/productContainer/productContainer.scss` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6890d55a2fb08324b7f1cd8f67d6aef8