### PR TITLE
Separate product search bar and filters

### DIFF
--- a/whatsapp_connector/static/src/components/productContainer/productContainer.scss
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.scss
@@ -7,36 +7,37 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
 
     .o_product_header {
-        position: sticky; 
+        position: sticky;
         top: 0;
         z-index: 10;
         background: #F9FAFB;
         padding: 12px 16px;
         margin-bottom: 16px;
+    }
 
-        .o_product_filters {
+    .o_product_filters {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        margin-left: 0;
+        margin-bottom: 16px;
+
+        .form-select {
+            border-radius: 6px;
+            border: 1px solid #D1D5DB;
+            font-size: 14px;
+            color: #374151;
+        }
+
+        label {
+            margin-bottom: 0;
             display: flex;
             align-items: center;
-            gap: 16px;
-            margin-left: 0;
-            
-            .form-select {
-                border-radius: 6px;
-                border: 1px solid #D1D5DB;
-                font-size: 14px;
-                color: #374151;
-            }
+            gap: 8px;
+            color: #6B7280;
 
-            label {
-                margin-bottom: 0;
-                display: flex;
-                align-items: center;
-                gap: 8px;
-                color: #6B7280;
-                
-                input[type="checkbox"] {
-                    accent-color: #6366F1; 
-                }
+            input[type="checkbox"] {
+                accent-color: #6366F1;
             }
         }
     }

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.xml
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.xml
@@ -5,26 +5,26 @@
         <div class="acrux_ProductContainer" t-attf-class="{{ props.className }}">
             <ChatroomHeader className="'o_product_header'">
                 <ChatSearch placeHolder="placeHolder" eventName="'productSearch'" />
-                <div class="o_product_filters">
-                    <select class="form-select form-select-sm me-2" t-on-change="changeStockFilter">
-                        <option value="positive">Unidades disponibles</option>
-                        <option value="negative">Sin unidades</option>
-                        <option value="all">Todos</option>
-                    </select>
-                    <label class="me-2">
-                        <input type="checkbox" t-on-change="toggleSearchName" t-att-checked="state.searchName"/>
-                        <span> Nombre</span>
-                    </label>
-                    <label class="me-2">
-                        <input type="checkbox" t-on-change="toggleSearchDefaultCode" t-att-checked="state.searchDefaultCode"/>
-                        <span> Referencia</span>
-                    </label>
-                    <label>
-                        <input type="checkbox" t-on-change="toggleSearchDescription" t-att-checked="state.searchDescription"/>
-                        <span> Descripción</span>
-                    </label>
-                </div>
             </ChatroomHeader>
+            <div class="o_product_filters">
+                <select class="form-select form-select-sm me-2" t-on-change="changeStockFilter">
+                    <option value="positive">Unidades disponibles</option>
+                    <option value="negative">Sin unidades</option>
+                    <option value="all">Todos</option>
+                </select>
+                <label class="me-2">
+                    <input type="checkbox" t-on-change="toggleSearchName" t-att-checked="state.searchName"/>
+                    <span> Nombre</span>
+                </label>
+                <label class="me-2">
+                    <input type="checkbox" t-on-change="toggleSearchDefaultCode" t-att-checked="state.searchDefaultCode"/>
+                    <span> Referencia</span>
+                </label>
+                <label>
+                    <input type="checkbox" t-on-change="toggleSearchDescription" t-att-checked="state.searchDescription"/>
+                    <span> Descripción</span>
+                </label>
+            </div>
             <div class="o_acrux_chat_product_items">
                 <t t-foreach="state.products" t-as="product" t-key="product.id">
                     <Product product="product" />


### PR DESCRIPTION
## Summary
- move product filter div outside header so search and filters render on separate rows
- style filters as standalone block with flex layout and bottom margin

## Testing
- `python3 -m odoo --version` (fails: No module named odoo)
- `npx sass whatsapp_connector/static/src/components/productContainer/productContainer.scss` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68910a83a8e48324af0316e6dcbbd6af