### PR TITLE
Add image search option in Google search tab

### DIFF
--- a/whatsapp_connector/static/src/components/tabsContainer/tabsContainer.scss
+++ b/whatsapp_connector/static/src/components/tabsContainer/tabsContainer.scss
@@ -162,7 +162,18 @@
 }
 
 .o_GoogleSearchForm {
-    input {
-        width: 80%;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    input[type="text"] {
+        flex: 1 1 auto;
+    }
+
+    label {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        margin-bottom: 0;
     }
 }

--- a/whatsapp_connector/static/src/components/tabsContainer/tabsContainer.xml
+++ b/whatsapp_connector/static/src/components/tabsContainer/tabsContainer.xml
@@ -63,6 +63,14 @@
                 <div class="o_GoogleSearchTab">
                     <form action="https://www.google.com/search" method="get" target="_blank" class="o_GoogleSearchForm">
                         <input type="text" name="q" placeholder="Search Google..." required="required"/>
+                        <label>
+                            <input type="checkbox" checked="checked"/>
+                            Web
+                        </label>
+                        <label>
+                            <input type="checkbox" name="tbm" value="isch"/>
+                            Imágenes
+                        </label>
                         <button type="submit" class="btn btn-primary">Search</button>
                     </form>
                 </div>


### PR DESCRIPTION
## Summary
- add Web and Imágenes checkboxes to Google search form
- style Google search form for inline layout

## Testing
- `pytest`
- `curl -I https://www.google.com/search?q=odoo` (fails: 403 Forbidden)
- `curl -I 'https://www.google.com/search?q=odoo&tbm=isch'` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689220ddab6c832494c11a0674b55a88