### PR TITLE
Add default category filter to product search

### DIFF
--- a/product_cant_tecnolosys/views/product_template_views.xml
+++ b/product_cant_tecnolosys/views/product_template_views.xml
@@ -29,7 +29,7 @@
 
     
 
-     <record id="view_product_template_tree_inhirited_stock" model="ir.ui.view">
+    <record id="view_product_template_tree_inhirited_stock" model="ir.ui.view">
         <field name="name">product.template.tree.hide.attributes</field>
         <field name="model">product.template</field>
         <field name="inherit_id" ref="stock.view_stock_product_template_tree"/>
@@ -40,6 +40,18 @@
                 <xpath expr="//field[@name='virtual_available']" position="attributes">
                     <attribute name="optional">hide</attribute>
                 </xpath>
+        </field>
+    </record>
+
+
+    <record id="view_product_template_search_inherit_category" model="ir.ui.view">
+        <field name="name">product.template.search.inherit.category</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_search_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//search" position="inside">
+                <filter name="category" string="Categoria" domain="[]" context="{'group_by': 'categ_id'}" default="1"/>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
## Summary
- add a "Categoria" filter grouping products by their category in the product search view

## Testing
- `python -m py_compile product_cant_tecnolosys/models/product.py`
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('product_cant_tecnolosys/views/product_template_views.xml')
print('XML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6893b1c89240832487cc966ee03f433f