### PR TITLE
Add category filter to product search

### DIFF
--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -736,7 +736,8 @@ class AcruxChatConversation(models.Model):
                 search_name = filters.get('search_name')
                 search_description = filters.get('search_description')
                 search_default_code = filters.get('search_default_code')
-                if search_name or search_description or search_default_code:
+                search_categ_id = filters.get('search_categ_id')
+                if search_name or search_description or search_default_code or search_categ_id:
                     exprs = []
                     if search_name:
                         exprs.append([('product_tmpl_id.name', 'ilike', string)])
@@ -744,6 +745,8 @@ class AcruxChatConversation(models.Model):
                         exprs.append([('product_tmpl_id.description', 'ilike', string)])
                     if search_default_code:
                         exprs.append([('default_code', 'ilike', string)])
+                    if search_categ_id:
+                        exprs.append([('product_tmpl_id.categ_id.name', 'ilike', string)])
                     if exprs:
                         domain += expression.OR(exprs)
                 else:

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.xml
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.xml
@@ -20,6 +20,10 @@
                     <input type="checkbox" t-on-change="toggleSearchDefaultCode" t-att-checked="state.searchDefaultCode"/>
                     <span> Referencia</span>
                 </label>
+                <label class="me-2">
+                    <input type="checkbox" t-on-change="toggleSearchCategory" t-att-checked="state.searchCategory"/>
+                    <span> Categoría</span>
+                </label>
                 <label>
                     <input type="checkbox" t-on-change="toggleSearchDescription" t-att-checked="state.searchDescription"/>
                     <span> Descripción</span>

--- a/whatsapp_connector/static/src/jslib/chatroom.js
+++ b/whatsapp_connector/static/src/jslib/chatroom.js
@@ -1462,6 +1462,7 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
         searchName: true,
         searchDescription: false,
         searchDefaultCode: true,
+        searchCategory: true,
       })
       this.lastSearch = ''
       this.props
@@ -1484,6 +1485,7 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
         search_name: this.state.searchName,
         search_description: this.state.searchDescription,
         search_default_code: this.state.searchDefaultCode,
+        search_categ_id: this.state.searchCategory,
       }
       const result = await orm.call(
         this.env.chatModel,
@@ -1507,6 +1509,10 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
     }
     toggleSearchDefaultCode() {
       this.state.searchDefaultCode = !this.state.searchDefaultCode
+      this.searchProduct({ search: this.lastSearch })
+    }
+    toggleSearchCategory() {
+      this.state.searchCategory = !this.state.searchCategory
       this.searchProduct({ search: this.lastSearch })
     }
     async productOption({ product, event }) { if (this.props.selectedConversation) { if (this.props.selectedConversation.isMine()) { await this.doProductOption({ product, event }) } else { this.env.services.dialog.add(WarningDialog, { message: this.env._t('Yoy are not writing in this conversation.') }) } } else { this.env.services.dialog.add(WarningDialog, { message: this.env._t('You must select a conversation.') }) } }


### PR DESCRIPTION
## Summary
- allow filtering products by category
- include category criterion in search API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893b4099a408324bd2817e52e9e66ac