### PR TITLE
Fix category name search in product lookup

### DIFF
--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -746,7 +746,7 @@ class AcruxChatConversation(models.Model):
                     if search_default_code:
                         exprs.append([('default_code', 'ilike', string)])
                     if search_categ_id:
-                        exprs.append([('product_tmpl_id.categ_id.name', 'ilike', string)])
+                        exprs.append([('categ_id.complete_name', 'ilike', string)])
                     if exprs:
                         domain += expression.OR(exprs)
                 else:


### PR DESCRIPTION
## Summary
- use category complete name when filtering products by category during search

## Testing
- `python -m py_compile whatsapp_connector/models/Conversation.py`


------
https://chatgpt.com/codex/tasks/task_e_6893c702a5e883249e371d47953f3edf