### PR TITLE
Expand product category search fields

### DIFF
--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -747,6 +747,8 @@ class AcruxChatConversation(models.Model):
                         exprs.append([('default_code', 'ilike', string)])
                     if search_categ_id:
                         exprs.append([('categ_id.complete_name', 'ilike', string)])
+                        exprs.append([('categ_id.name', 'ilike', string)])
+                        exprs.append([('categ_id.parent_id.name', 'ilike', string)])
                     if exprs:
                         domain += expression.OR(exprs)
                 else:


### PR DESCRIPTION
## Summary
- allow product search category filter to match category name and parent name

## Testing
- `python -m py_compile whatsapp_connector/models/Conversation.py`


------
https://chatgpt.com/codex/tasks/task_e_6895fe80bc24832497de8a4385335f55