### PR TITLE
feat: show product count and adjustable limit

### DIFF
--- a/chatroom_cantidad_productos/models/conversation.py
+++ b/chatroom_cantidad_productos/models/conversation.py
@@ -20,13 +20,15 @@ class AcruxChatConversation(models.Model):
         return fields_search
 
     @api.model
-    def search_product(self, string, filters=None):
-        products = super().search_product(string, filters=filters)
+    def search_product(self, string, filters=None, limit=32):
+        result = super().search_product(string, filters=filters, limit=limit)
 
+        products = result.get('products', [])
         if 'quantity_total' in self.env['product.product']._fields:
             stock_filter = (filters or {}).get('stock_filter', 'positive')
             if stock_filter == 'positive':
                 products = [p for p in products if p.get('quantity_total', 0) > 0]
             elif stock_filter == 'negative':
                 products = [p for p in products if p.get('quantity_total', 0) < 0]
-        return products
+        result['products'] = products
+        return result

--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -717,7 +717,7 @@ class AcruxChatConversation(models.Model):
         return fields_search
 
     @api.model
-    def search_product(self, string, filters=None):
+    def search_product(self, string, filters=None, limit=32):
         ProductProduct = self.env['product.product']
         domain = [('sale_ok', '=', True)]
         filters = filters or {}
@@ -752,8 +752,9 @@ class AcruxChatConversation(models.Model):
                 else:
                     domain += ['|', ('name', 'ilike', string), ('default_code', 'ilike', string)]
         fields_search = self.get_product_fields_to_read()
-        out = ProductProduct.search_read(domain, fields_search, order='name, list_price', limit=32)
-        return out
+        out = ProductProduct.search_read(domain, fields_search, order='name, list_price', limit=limit)
+        total = ProductProduct.search_count(domain)
+        return {'products': out, 'total': total, 'limit': limit}
 
     def init_and_notify(self):
         self.ensure_one()

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.scss
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.scss
@@ -42,6 +42,16 @@
         }
     }
 
+    .o_product_limit {
+        margin-bottom: 16px;
+        color: #6B7280;
+
+        .o_limit_input {
+            width: 60px;
+            margin: 0 4px;
+        }
+    }
+
     .o_acrux_chat_product_items {
         flex: 1 1 auto;
         overflow-y: auto;

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.xml
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.xml
@@ -29,6 +29,11 @@
                     <span> Descripción</span>
                 </label>
             </div>
+            <div class="o_product_limit">
+                <span>Mostrando </span>
+                <input type="number" class="o_limit_input" t-on-change="updateLimit" t-att-value="state.limit"/>
+                <span>/ <t t-esc="state.total"/> resultados</span>
+            </div>
             <div class="o_acrux_chat_product_items">
                 <t t-foreach="state.products" t-as="product" t-key="product.id">
                     <Product product="product" />

--- a/whatsapp_connector/static/src/jslib/chatroom.js
+++ b/whatsapp_connector/static/src/jslib/chatroom.js
@@ -1463,6 +1463,8 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
         searchDescription: false,
         searchDefaultCode: true,
         searchCategory: true,
+        limit: 32,
+        total: 0,
       })
       this.lastSearch = ''
       this.props
@@ -1490,10 +1492,15 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
       const result = await orm.call(
         this.env.chatModel,
         'search_product',
-        [val.trim(), filters],
+        [val.trim(), filters, this.state.limit],
         { context: this.env.context },
       )
-      this.state.products = result.map(product => new ProductModel(this, product))
+      this.state.products = result.products.map(product => new ProductModel(this, product))
+      this.state.total = result.total
+    }
+    updateLimit(event) {
+      this.state.limit = parseInt(event.target.value, 10) || 0
+      this.searchProduct({ search: this.lastSearch })
     }
     changeStockFilter(event) {
       this.state.stockFilter = event.target.value


### PR DESCRIPTION
## Summary
- allow dynamic limit and return total on product search
- show product result count with user-controlled limit
- style product limit controls

## Testing
- `python -m py_compile whatsapp_connector/models/Conversation.py chatroom_cantidad_productos/models/conversation.py`
- `node --check whatsapp_connector/static/src/jslib/chatroom.js`


------
https://chatgpt.com/codex/tasks/task_e_68960dce64a483249a787bab14d18008