### PR TITLE
Add search operator option to product search and align result limit

### DIFF
--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -737,20 +737,21 @@ class AcruxChatConversation(models.Model):
                 search_description = filters.get('search_description')
                 search_default_code = filters.get('search_default_code')
                 search_categ_id = filters.get('search_categ_id')
+                search_operator = filters.get('search_operator', 'ilike')
                 if search_name or search_description or search_default_code or search_categ_id:
                     exprs = []
                     if search_name:
-                        exprs.append([('product_tmpl_id.name', 'ilike', string)])
+                        exprs.append([('product_tmpl_id.name', search_operator, string)])
                     if search_description:
-                        exprs.append([('product_tmpl_id.description', 'ilike', string)])
+                        exprs.append([('product_tmpl_id.description', search_operator, string)])
                     if search_default_code:
-                        exprs.append([('default_code', 'ilike', string)])
+                        exprs.append([('default_code', search_operator, string)])
                     if search_categ_id:
-                        exprs.append([('categ_id.complete_name', 'ilike', string)])
+                        exprs.append([('categ_id.complete_name', search_operator, string)])
                     if exprs:
                         domain += expression.OR(exprs)
                 else:
-                    domain += ['|', ('name', 'ilike', string), ('default_code', 'ilike', string)]
+                    domain += ['|', ('name', search_operator, string), ('default_code', search_operator, string)]
         fields_search = self.get_product_fields_to_read()
         out = ProductProduct.search_read(domain, fields_search, order='name, list_price', limit=limit)
         total = ProductProduct.search_count(domain)

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.scss
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.scss
@@ -45,6 +45,9 @@
     .o_product_limit {
         margin-bottom: 16px;
         color: #6B7280;
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
 
         .o_limit_input {
             width: 60px;

--- a/whatsapp_connector/static/src/components/productContainer/productContainer.xml
+++ b/whatsapp_connector/static/src/components/productContainer/productContainer.xml
@@ -4,7 +4,20 @@
     <t t-name="chatroom.ProductContainer" owl="1">
         <div class="acrux_ProductContainer" t-attf-class="{{ props.className }}">
             <ChatroomHeader className="'o_product_header'">
-                <ChatSearch placeHolder="placeHolder" eventName="'productSearch'" />
+                <div class="d-flex align-items-center w-100">
+                    <ChatSearch placeHolder="placeHolder" eventName="'productSearch'" />
+                    <div class="dropdown ms-2">
+                        <button class="btn btn-sm btn-secondary fa fa-filter dropdown-toggle" type="button" data-bs-toggle="dropdown" />
+                        <ul class="dropdown-menu">
+                            <li>
+                                <a class="dropdown-item" t-on-click="setSearchMatch('ilike')" t-att-class="{'active': state.searchMatch === 'ilike'}">Coincidencias</a>
+                            </li>
+                            <li>
+                                <a class="dropdown-item" t-on-click="setSearchMatch('=')" t-att-class="{'active': state.searchMatch === '='}">Estrictamente igual</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
             </ChatroomHeader>
             <div class="o_product_filters">
                 <select class="form-select form-select-sm me-2" t-on-change="changeStockFilter">

--- a/whatsapp_connector/static/src/jslib/chatroom.js
+++ b/whatsapp_connector/static/src/jslib/chatroom.js
@@ -1463,6 +1463,7 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
         searchDescription: false,
         searchDefaultCode: true,
         searchCategory: true,
+        searchMatch: 'ilike',
         limit: 32,
         total: 0,
       })
@@ -1488,6 +1489,7 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
         search_description: this.state.searchDescription,
         search_default_code: this.state.searchDefaultCode,
         search_categ_id: this.state.searchCategory,
+        search_operator: this.state.searchMatch,
       }
       const result = await orm.call(
         this.env.chatModel,
@@ -1504,6 +1506,10 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
     }
     changeStockFilter(event) {
       this.state.stockFilter = event.target.value
+      this.searchProduct({ search: this.lastSearch })
+    }
+    setSearchMatch(match) {
+      this.state.searchMatch = match
       this.searchProduct({ search: this.lastSearch })
     }
     toggleSearchName() {


### PR DESCRIPTION
## Summary
- add dropdown to product search allowing `Coincidencias` or `Estrictamente igual`
- support chosen operator in backend product lookup
- align limit selector text and input to the right

## Testing
- `python -m py_compile whatsapp_connector/models/Conversation.py`

------
https://chatgpt.com/codex/tasks/task_e_68961413bddc8324a509f2385bba2b9a