### PR TITLE
Limit promotions to specific program names

### DIFF
--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -730,6 +730,7 @@ class AcruxChatConversation(models.Model):
                 ('reward_type', '=', 'discount'),
                 ('discount', '>', 0),
                 ('program_id.program_type', '=', 'promotion'),
+                ('program_id.name', 'in', ['flash_sale', 'day_sale', 'week_sale']),
             ])
             product_ids = set()
             product_ids.update(


### PR DESCRIPTION
## Summary
- filter promotion rewards by program name to include flash, day and week sales only

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ca89847d88324891221745d4158ea