### PR TITLE
Fix promotion product search mapping

### DIFF
--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -734,7 +734,7 @@ class AcruxChatConversation(models.Model):
             ])
             product_ids = set()
             product_ids.update(
-                promo_rewards.mapped('discount_product_ids.product_variant_ids').ids
+                promo_rewards.mapped('discount_product_ids').ids
             )
             categ_ids = promo_rewards.mapped('discount_product_category_id.id')
             if categ_ids:


### PR DESCRIPTION
## Summary
- fix promotion product search by retrieving discount products directly

## Testing
- `python -m py_compile whatsapp_connector/models/Conversation.py`


------
https://chatgpt.com/codex/tasks/task_e_689cab93c40c83248ae0c6482bdc4771