### PR TITLE
Fix promotion search to include all products

### DIFF
--- a/whatsapp_connector/static/src/jslib/chatroom.js
+++ b/whatsapp_connector/static/src/jslib/chatroom.js
@@ -1548,13 +1548,14 @@ odoo.define('@aedb85b64f8970ed4ccdcfb5fad7484eb5f9502792073b672b574c2d95ef5fe2',
       const result = await orm.call(
         this.env.chatModel,
         'search_product',
-        ['', filters, this.state.limit],
+        ['', filters, 0],
         { context: this.env.context },
       )
       this.state.allProducts = result.products.map(product => new ProductModel(this, product))
       this.state.categories = (result.categories || []).map(cat => ({ ...cat, selected: true }))
       this.applyCategoryFilter()
       this.state.total = result.total
+      this.state.limit = result.limit
     }
     async productOption({ product, event }) { if (this.props.selectedConversation) { if (this.props.selectedConversation.isMine()) { await this.doProductOption({ product, event }) } else { this.env.services.dialog.add(WarningDialog, { message: this.env._t('Yoy are not writing in this conversation.') }) } } else { this.env.services.dialog.add(WarningDialog, { message: this.env._t('You must select a conversation.') }) } }
     async doProductOption({ product }) {


### PR DESCRIPTION
## Summary
- expand promotion product lookup without program name restriction
- return all promotional products when viewing promotions
- load all promotions on front end without limit

## Testing
- `python -m py_compile whatsapp_connector/models/Conversation.py`
- `node --check whatsapp_connector/static/src/jslib/chatroom.js`


------
https://chatgpt.com/codex/tasks/task_e_689caedd336c8324a8dc2e531c39488f