### PR TITLE
Show sale badge with discount percentage

### DIFF
--- a/whatsapp_connector/static/src/components/product/product.xml
+++ b/whatsapp_connector/static/src/components/product/product.xml
@@ -19,7 +19,12 @@
                                     <t t-esc="formatPrice(props.product.lstPrice)" />
                                 </span>
                                 <t t-if="props.product.isPromotion">
-                                    <span class="badge bg-success ms-1">Promoción</span>
+                                    <span class="badge bg-danger ms-1 text-white">
+                                        SALE
+                                        <t t-if="props.product.discountPercentage">
+                                            <t t-esc="props.product.discountPercentage" />%
+                                        </t>
+                                    </span>
                                 </t>
                                 <t t-if="props.product.type == 'product'">
                                     <t t-if="props.product.qtyAvailabletecno > 0.0"><t t-set="fcolor" t-value="'text-muted'"/></t>

--- a/whatsapp_connector/static/src/jslib/chatroom.js
+++ b/whatsapp_connector/static/src/jslib/chatroom.js
@@ -2422,6 +2422,7 @@ odoo.define('@a57f7a72eb29be2e68a9675edd680394d67e2ecd8df85dc2c38e83822c8551e8',
       this.uniqueHashImage = ''
       this.showOptions = true
       this.isPromotion = false
+      this.discountPercentage = 0
       if (base) { this.updateFromJson(base) }
     }
     updateFromJson(base) {
@@ -2447,6 +2448,7 @@ odoo.define('@a57f7a72eb29be2e68a9675edd680394d67e2ecd8df85dc2c38e83822c8551e8',
       if ('show_product_text' in base) { this.showProductText = base.show_product_text }
       if ('show_options' in base) { this.showOptions = base.show_options }
       if ('is_promotion' in base) { this.isPromotion = base.is_promotion }
+      if ('discount_percentage' in base) { this.discountPercentage = base.discount_percentage }
     }
   }
   return __exports;


### PR DESCRIPTION
## Summary
- compute discount percentage for promotion products and expose it via API
- show "SALE" badge with discount percentage in product template
- track discount percentage in ProductModel for frontend

## Testing
- `python -m py_compile whatsapp_connector/models/Conversation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ce79cf774832493b0aa10002098d0