### PR TITLE
Fix NameError in product caption evaluation

### DIFF
--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -477,6 +477,7 @@ class AcruxChatConversation(models.Model):
                 'format_price': format_price,
                 'product_id': product_id,
                 'conversation_id': self,
+                'self': self,
                 'product_url': self.get_product_url(product_id),
                 'sale': self.is_product_on_sale(product_id),
                 'text': ''


### PR DESCRIPTION
## Summary
- include self in the local context when evaluating product captions with `safe_eval` to avoid NameError

## Testing
- `python -m py_compile whatsapp_connector/models/Conversation.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf10eb3148324b1c0c624ad2c34e2