### PR TITLE
Expose is_on_sale flag for product captions

### DIFF
--- a/whatsapp_connector/models/Conversation.py
+++ b/whatsapp_connector/models/Conversation.py
@@ -472,6 +472,7 @@ class AcruxChatConversation(models.Model):
         if product_caption:
             def format_price(price):
                 return formatLang(self.env, price, currency_obj=self.env.company.currency_id)
+            is_on_sale = self.is_product_on_sale(product_id)
             local_dict = {
                 'env': self.env,
                 'format_price': format_price,
@@ -479,7 +480,9 @@ class AcruxChatConversation(models.Model):
                 'conversation_id': self,
                 'self': self,
                 'product_url': self.get_product_url(product_id),
-                'sale': self.is_product_on_sale(product_id),
+                # expose sale information with two keys for compatibility
+                'is_on_sale': is_on_sale,
+                'sale': is_on_sale,
                 'text': ''
             }
             safe_eval(product_caption, locals_dict=local_dict, mode='exec', nocopy=True)


### PR DESCRIPTION
## Summary
- expose `is_on_sale` flag along with `sale` when building product captions to avoid NameError during template evaluation

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf265f00083248f7b4edb5cff57eb